### PR TITLE
Fixed issue preventing scrolling on some browsers

### DIFF
--- a/www/include/html_desktop.inc.php
+++ b/www/include/html_desktop.inc.php
@@ -33,7 +33,7 @@ print <<<EOL
     <script type="text/javascript" src="{$baseURL}/include/js/global.js" language="javascript"></script>
     {$conf['html_headers']}
 </head>
-<body style="overflow: hidden;" bgcolor="{$color['bg']}" link="{$color['link']}" alink="{$color['alink']}" vlink="{$color['vlink']}">
+<body style="overflow: auto;" bgcolor="{$color['bg']}" link="{$color['link']}" alink="{$color['alink']}" vlink="{$color['vlink']}">
 
     <!-- Top (Task) Bar -->
     <div class="menubar" id="bar_topmenu" style="background-color: {$self['context_color']}">


### PR DESCRIPTION
Setting the body style attribute "overflow: hidden" prevents scrolling when
rendered content exceeds the window size under certain conditions.

This fix changes the overflow value to "auto" which lets the browser add
scrolling when necessary.
