### PR TITLE
Input array has 1 params, doERROR => SQL query failed:

### DIFF
--- a/www/modules/sql.inc.php
+++ b/www/modules/sql.inc.php
@@ -216,8 +216,14 @@ EOM
 
     printmsg("DEBUG => [ona_sql] Running SQL query: {$options['sql']}",5);
 
-    // Run the query
-    $rs = $onadb->Execute($options['sql'],$sqlopts);
+    //  Check if we have anything in $sqlopts
+    if (!$sqlopts) {
+        // Run the query
+        $rs = $onadb->Execute($options['sql']);
+    } else {
+        // Run the query with the options
+        $rs = $onadb->Execute($options['sql'],$sqlopts);
+    }
 
     if ($rs === false) {
         $self['error'] = "ERROR => SQL query failed: " . $onadb->ErrorMsg() . "\n";


### PR DESCRIPTION
I belive ADODB has changet somewhat.
If you supply 2 vars to the Execute function and one is empty you get this error message.

Adds a check to see if $sqlopt is empty then run Execute without it.