### PR TITLE
dpd's inet dlz 20180419a

### DIFF
--- a/docs/DPD-DLZ-INET-Chanages.md
+++ b/docs/DPD-DLZ-INET-Chanages.md
@@ -1,0 +1,34 @@
+OpenNetAdmin - dpd's BIND-DLZ w/ v6 and INET function compatibility
+============
+
+ONA allowed for BIND-DLZ extension to perform dynamic lookups via your 
+ONA MySQL database.  However, this didn't support PTR (very well) or V6 
+and required a really convoluted view that made it very difficult to fix
+the v6 et al issues that arrose.
+
+So, I have design a very small delta patch, that should allow for v6 and 
+and both v4 and v6 PTR, NS, MX and SOA records to be severed correctly, 
+with a horrible long, but easier to use query.
+
+The PHP code is changes, but two install scripts need to be run manually.
+
+---
+**Changes**
+
+ * `install/inet-functions.sql`
+   Very minimal schema changes, just adding one column to interfaces, for the VARBINARY(16), so the the inet6_atoi/inet6_ntoi and php's inet_pton/inet_ntop can be used.  Also adds three indexes for fields that DLZ uses to search by.
+ * `install/inet-functions.php` base script copied from 2-to-3.php. This will do a few things 
+   * Finds/Creates all domains and creates a meta "SOA" type row in the DNS table.  Because of how DLZ queries (without a "type", just the string of lookup) - it is much easier to have this via one table, and use cases in the sql to change up the data formating.   So a fake SOA record is here, pretty much just linking the domain ID and type together. All other fields are ignored.  Doesn't break backwards compat, ONA seems to ignore the SOA type.  Code changes provides the creation of SOAs upon domain creation.
+   * Updates the dns.name of all PTR records.  Again, how Bind DLZ does queries, there was no good way to do reverse lookups.  ONA already ignored the dns.name field, for v4 PTRs, so, in this case overloading  dns.name with the last two octets.  Again, a strange things with BIND-DLZ ... is it will not lookup the first octet + in-arpa for the domain name ($zone$, ex 10.in-addr.arpa, but it will search 2.10.in-addr.arpa ) and DLZ will only successfully search the first octet of .ip6.arpa), with the $record$ slowly building out in reverse octets. 
+   * add in all two-octet in-addr.arpa domains, as encounter by IP. Because of the above, will auto create all the needed in-addr.arpa for v4. Should also handle v6 as well.
+   * Populate the ip_addr_inet field.  Will scan all interfaces, and update the IP address for both v4 and v6.  ip_addr_inet is not used by ONA, other than to updated durning edit or insert (code changes provided).
+
+**Notable Code Changes**
+   * Fixed undefined PHP warnings using isset() checks, especially running in CLI.  It was hard to see my own debugging output. By far, not extensive fixes, but proper PHP syntax/usage/style.
+   * Allow AAAA to be AAAA.  Removed a few stops where v6 quad-a records are remapped to A. Was required for some reason.
+   * random PHP 7.x fix. (functions_gui.inc.php) (Testing & developed using PHP 7.2.3 on FreeBSD, w/ file based sessions)
+   * modules/ona/domain.inc.php - adds the SOA dns record.
+   * modules/ona/interface.inc.php - populates and updates `ip_addr_inet` base on ip_addr & ip_mangle()
+   * modules/ona/dns_record.inc.php - various tweaks for v6, as well as setting dns.name for PTR records.
+
+

--- a/inet-functions.php
+++ b/inet-functions.php
@@ -1,0 +1,142 @@
+<?php
+//
+// This script is to be used when applying the inet[46]_[aton|ntoa] support for BIND-DLZ
+// It will update all PTRs, so they can be served directly from the DNS tables
+// Will add ONA unsupport DNS type of SOA in order to provide a complete solution
+// for BIND DLZ without using views.
+//
+//
+/* -------------------- COMMON HEADER ---------------------- */
+$base = dirname(__FILE__)."/../www/";
+while ($base and (!is_dir($base.'/include'))) $base = preg_replace('+/[^/]*$+', '', $base);
+$include = $base . '/include';
+if (!is_dir($include)) { print "ERROR => Couldn't find include folder {$include}!\n"; exit; }
+require_once($base . '/config/config.inc.php');
+/* --------------------------------------------------------- */
+
+global $conf, $self, $onadb;
+
+// Uncomment the following to get a ton o' debug
+//$conf['debug'] = 6;
+echo "Checking for SOA meta records:\n";
+
+list($status, $rows, $domains) = db_get_records($onadb, 'domains', 'id > 0');
+#print_r ( $domains );
+foreach ( $domains as $d ) {
+    list($status, $rows, $soa) = db_get_records($onadb, 'dns', "type = 'SOA' and domain_id = '" . $d['id'] . "' ");
+    if ( $rows == 0 ) {
+        printf ("{%36s} - doesn't have an SOA DNS Record. \n", $d['name'] );
+        // Add the dns record
+        $dns_id = ona_get_next_id('dns');
+        list($status, $rows) = db_insert_record(
+            $onadb,
+            'dns',
+            array(
+                'id'                   => $dns_id,
+                'domain_id'            => $d['id'],
+                'interface_id'         => 0,
+                'dns_id'               => 0,
+                'type'                 => 'SOA',
+                'ttl'                  => 0,
+                'name'                 => '',
+                'mx_preference'        => '0',
+                'txt'                  => '',
+                'srv_pri'              => 0,
+                'srv_weight'           => 0,
+                'srv_port'             => 0,
+                'notes'                => '',
+                'dns_view_id'          => 0
+             )
+        );                
+        if ($status or !$rows) {
+            printf ("{%36s} - SOA DNS Record insert FAILED. \n", $d['name'] );        
+        } else {
+            printf ("{%36s} - SOA DNS Record created. \n", $d['name'] );
+        }
+        
+    } else {
+        printf ("{%36s} - has an SOA DNS Record. \n", $d['name'] );
+    }
+}
+
+// Get the PTR records that dont have a domain_id
+list($status, $rows, $ptrs) = db_get_records($onadb, 'dns', "type = 'PTR'", '');
+echo "Found {$rows} PTR with ptr records - will update all of them\n";
+
+foreach ($ptrs as $ptr) {
+    list($status, $rows, $interface) = ona_get_interface_record(array('id' => $ptr['interface_id']));
+
+    // Print an error if it doesnt find an IP
+    if (!$interface['ip_addr']) {
+        echo "Possible orphan PTR record in dns table at ID: {$ptr['id']}.  You should delete this record manually.\n";
+        continue;
+    }
+
+    $ipflip = ip_mangle($interface['ip_addr'],'flip');
+            $octets = explode(".",$ipflip);
+            if (count($octets) > 4) {
+                $arpa = 'ip6.arpa';
+                $octcount = 31;
+		#$domain = $arpa;
+		$a = array ();
+		for ($i=$octcount; $i>$octcount-11; $i--) {
+			array_push ($a, $octets[$i]);
+		}
+		array_push  ($a, $arap );
+		$domain = implode (".", $a);
+		$_name = '';
+		$a = array ();
+		for ($i=$octcount-11; $i>=0; $i--) {
+			array_push ($a, $octets[$i]);
+		}
+		$_name  = implode (".", $a);
+            } else {
+                $arpa = 'in-addr.arpa';
+                $octcount = 3;
+		$domain = $octets[2] . "." . $octets[3] . "." . $arpa;
+		$_name = $octets[0] . "." . $octets[1];
+            }
+            // Find a pointer zone for this record to associate with.
+	   echo " Searching for $domain \n";
+       list($status, $prows, $ptrdomain) = ona_find_domain($domain);
+	   echo "   => Found for $domain => " . $ptrdomain['id'] . " " . $ptrdomain['name'] ."\n" ;
+
+	    // print_r ( $ptrdomain );
+    // CRAPPY security cludge
+    $_SESSION['ona']['auth']['user']['username'] = 'PTRFIX';
+    $_SESSION['ona']['auth']['perms']['advanced'] = 'Y';
+    $_SESSION['ona']['auth']['perms']['host_modify'] = 'Y';
+
+    if (!$ptrdomain['id'] or ($domain != $ptrdomain['name']) ) {
+        echo "  {$interface['ip_addr_text']}: Unable to find a pointer domain for this IP! Creating the following DNS domain: {$domain} \n";
+        list($status, $output) = run_module('domain_add', array('name' => $domain));
+        if ($status) {
+            echo "ERROR => {$output}\n";
+            exit($status);
+        }
+        list($status, $rows, $ptrdomain) = ona_find_domain($domain);
+    }
+
+    // Found a domain to put them in.
+    echo "  Updating PTR for IP {$interface['ip_addr_text']} to $ipflip.in-addr.arpa\n";
+
+    // Change the actual DNS record
+    list($status, $rows) = db_update_record($onadb, 'dns', array('id' => $ptr['id']), array( 'name' => $_name, 'domain_id' => $ptrdomain['id']  ));
+    // if ($status or !$rows) {
+    //    echo "ERROR => SQL Query failed updating dns record: " . $self['error'] . " $status \n" ;
+    //    exit(2);
+    // }
+
+
+}
+
+list($status, $rows, $interfaces) = db_get_records($onadb, 'interfaces', "ip_addr is not null", '');
+foreach ($interfaces as $interface ) {
+    echo "  Adding inet6_atoi field  " . $interface['id'] . "\n";
+    list($status, $rows) = db_update_record($onadb, 'interfaces', array('id' => $interface['id']), array ('ip_addr_inet' => inet_format($interface['ip_addr'])  ));
+
+}
+
+exit(0);
+
+?>

--- a/inet-functions.sql
+++ b/inet-functions.sql
@@ -1,0 +1,4 @@
+alter table interfaces add `ip_addr_inet` varbinary(16) default NULL;
+CREATE INDEX domains_name_index ON domains (name);
+CREATE INDEX dns_name_index ON dns (name);
+CREATE INDEX type_index ON dns (type);

--- a/install/inet-functions.php
+++ b/install/inet-functions.php
@@ -1,0 +1,132 @@
+<?php
+//
+// This script is to be used when applying the inet[46]_[aton|ntoa] support for BIND-DLZ
+// It will update all PTRs, so they can be served directly from the DNS tables
+// Will add ONA unsupport DNS type of SOA in order to provide a complete solution
+// for BIND DLZ without using views.
+//
+//
+/* -------------------- COMMON HEADER ---------------------- */
+$base = dirname(__FILE__)."/../www/";
+while ($base and (!is_dir($base.'/include'))) $base = preg_replace('+/[^/]*$+', '', $base);
+$include = $base . '/include';
+if (!is_dir($include)) { print "ERROR => Couldn't find include folder {$include}!\n"; exit; }
+require_once($base . '/config/config.inc.php');
+/* --------------------------------------------------------- */
+
+global $conf, $self, $onadb;
+
+// Uncomment the following to get a ton o' debug
+//$conf['debug'] = 6;
+echo "Checking for SOA meta records:\n";
+
+list($status, $rows, $domains) = db_get_records($onadb, 'domains', 'id > 0');
+#print_r ( $domains );
+foreach ( $domains as $d ) {
+    list($status, $rows, $soa) = db_get_records($onadb, 'dns', "type = 'SOA' and domain_id = '" . $d['id'] . "' ");
+    if ( $rows == 0 ) {
+        printf ("{%36s} - doesn't have an SOA DNS Record. \n", $d['name'] );
+        // Add the dns record
+        $dns_id = ona_get_next_id('dns');
+        list($status, $rows) = db_insert_record(
+            $onadb,
+            'dns',
+            array(
+                'id'                   => $dns_id,
+                'domain_id'            => $d['id'],
+                'interface_id'         => 0,
+                'dns_id'               => 0,
+                'type'                 => 'SOA',
+                'ttl'                  => 0,
+                'name'                 => '',
+                'mx_preference'        => '0',
+                'txt'                  => '',
+                'srv_pri'              => 0,
+                'srv_weight'           => 0,
+                'srv_port'             => 0,
+                'notes'                => '',
+                'dns_view_id'          => 0
+             )
+        );                
+        if ($status or !$rows) {
+            printf ("{%36s} - SOA DNS Record insert FAILED. \n", $d['name'] );        
+        } else {
+            printf ("{%36s} - SOA DNS Record created. \n", $d['name'] );
+        }
+        
+    } else {
+        printf ("{%36s} - has an SOA DNS Record. \n", $d['name'] );
+    }
+}
+
+// Get the PTR records that dont have a domain_id
+list($status, $rows, $ptrs) = db_get_records($onadb, 'dns', "type = 'PTR'", '');
+echo "Found {$rows} PTR with ptr records - will update all of them\n";
+
+foreach ($ptrs as $ptr) {
+    list($status, $rows, $interface) = ona_get_interface_record(array('id' => $ptr['interface_id']));
+
+    // Print an error if it doesnt find an IP
+    if (!$interface['ip_addr']) {
+        echo "Possible orphan PTR record in dns table at ID: {$ptr['id']}.  You should delete this record manually.\n";
+        continue;
+    }
+
+    $ipflip = ip_mangle($interface['ip_addr'],'flip');
+    $octets = explode(".",$ipflip);
+    if (count($octets) > 4) {
+        $arpa = 'ip6.arpa';
+        $octcount = 31;
+        $a = array_reverse ( $octets )
+        $domain = implode (".", $a);
+        $_name = '';
+        $domain  = implode (".", array ($a[0], $arpa) );
+    } else {
+        $arpa = 'in-addr.arpa';
+        $octcount = 3;
+        $domain = $octets[2] . "." . $octets[3] . "." . $arpa;
+        $_name = $octets[0] . "." . $octets[1];
+    }
+    // Find a pointer zone for this record to associate with.
+    echo " Searching for $domain \n";
+    list($status, $prows, $ptrdomain) = ona_find_domain($domain);
+    echo "   => Found for $domain => " . $ptrdomain['id'] . " " . $ptrdomain['name'] ."\n" ;
+
+    // CRAPPY security cludge
+    $_SESSION['ona']['auth']['user']['username'] = 'PTRFIX';
+    $_SESSION['ona']['auth']['perms']['advanced'] = 'Y';
+    $_SESSION['ona']['auth']['perms']['host_modify'] = 'Y';
+
+    if (!$ptrdomain['id'] or ($domain != $ptrdomain['name']) ) {
+        echo "  {$interface['ip_addr_text']}: Unable to find a pointer domain for this IP! Creating the following DNS domain: {$domain} \n";
+        list($status, $output) = run_module('domain_add', array('name' => $domain));
+        if ($status) {
+            echo "ERROR => {$output}\n";
+            exit($status);
+        }
+        list($status, $rows, $ptrdomain) = ona_find_domain($domain);
+    }
+
+    // Found a domain to put them in.
+    echo "  Updating PTR for IP {$interface['ip_addr_text']} to $ipflip.in-addr.arpa\n";
+
+    // Change the actual DNS record
+    list($status, $rows) = db_update_record($onadb, 'dns', array('id' => $ptr['id']), array( 'name' => $_name, 'domain_id' => $ptrdomain['id']  ));
+    // if ($status or !$rows) {
+    //    echo "ERROR => SQL Query failed updating dns record: " . $self['error'] . " $status \n" ;
+    //    exit(2);
+    // }
+
+
+}
+
+list($status, $rows, $interfaces) = db_get_records($onadb, 'interfaces', "ip_addr is not null", '');
+foreach ($interfaces as $interface ) {
+    echo "  Adding inet6_atoi field  " . $interface['id'] . "\n";
+    list($status, $rows) = db_update_record($onadb, 'interfaces', array('id' => $interface['id']), array ('ip_addr_inet' => inet_format($interface['ip_addr'])  ));
+
+}
+
+exit(0);
+
+?>

--- a/install/inet-functions.sql
+++ b/install/inet-functions.sql
@@ -1,0 +1,4 @@
+alter table interfaces add `ip_addr_inet` varbinary(16) default NULL;
+CREATE INDEX domains_name_index ON domains (name);
+CREATE INDEX dns_name_index ON dns (name);
+CREATE INDEX type_index ON dns (type);

--- a/www/config/config.inc.php
+++ b/www/config/config.inc.php
@@ -30,9 +30,9 @@ $_ENV['help_url'] = "http://opennetadmin.com/docs/";
 
 
 // Get any query info
-parse_str($_SERVER['QUERY_STRING']);
-
-
+if ( isset($_SERVER['QUERY_STRING']) ) {
+    parse_str($_SERVER['QUERY_STRING']);
+}
 
 // Many of these settings serve as defaults.  They can be overridden by the settings in
 // the table "sys_config"
@@ -58,6 +58,7 @@ $conf = array (
     "inc_functions_gui"      => "$include/functions_gui.inc.php",
     "inc_functions_db"       => "$include/functions_db.inc.php",
     "inc_functions_auth"     => "$include/functions_auth.inc.php",
+    "inc_functions_inetformat"     => "$include/functions_inet_format.php",
     "inc_db_sessions"        => "$include/adodb_sessions.inc.php",
     "inc_adodb"              => "$include/adodb/adodb.inc.php",
     "inc_adodb_xml"          => "$include/adodb/adodb-xmlschema03.inc.php",
@@ -69,7 +70,7 @@ $conf = array (
     "plugin_dir"             => "$base/local/plugins",
 
     /* Defaults for some user definable options normally in sys_config table */
-    "debug"                  => "2",
+    "debug"                  => "16",
     "syslog"                 => "0",
     "stdout"                 => "0",
     "log_to_db"              => "0",
@@ -105,7 +106,7 @@ $self = array (
 );
 // If the server port is 443 then this is a secure page
 // This is basically used to put a padlock icon on secure pages.
-if ($_SERVER['SERVER_PORT'] == 443) { $self['secure'] = 1; }
+if (isset ($_SERVER['SERVER_PORT']) && ($_SERVER['SERVER_PORT'] == 443) ) { $self['secure'] = 1; }
 
 
 
@@ -168,6 +169,7 @@ $style['borderR'] = "border-right: 1px solid {$color['border']};";
 // Include the basic system functions
 // any $conf settings used in this "require" should not be user adjusted in the sys_config table
 require_once($conf['inc_functions']);
+require_once($conf['inc_functions_inetformat']);
 
 // Include the basic database functions
 require_once($conf['inc_functions_db']);
@@ -217,7 +219,7 @@ foreach ($records as $record) {
 }
 
 // Include functions that replace the default session handler with one that uses MySQL as a backend
-require_once($conf['inc_db_sessions']);
+# require_once($conf['inc_db_sessions']);
 
 // Include the GUI functions
 require_once($conf['inc_functions_gui']);
@@ -229,20 +231,25 @@ require_once($conf['inc_functions_auth']);
 startSession();
 
 // Set session inactivity threshold
-ini_set("session.gc_maxlifetime", $conf['cookie_life']);
+if ( isset ($_SERVER['REQUEST_METHOD']) ) {
+    ini_set("session.gc_maxlifetime", $conf['cookie_life']);
+}
 
 // if search_results_per_page is in the session, set the $conf variable to it.  this fixes the /rows command
 if (isset($_SESSION['search_results_per_page'])) $conf['search_results_per_page'] = $_SESSION['search_results_per_page'];
 
 // Set up our page to https if requested for our URL links
-if (@($conf['force_https'] == 1) or ($_SERVER['SERVER_PORT'] == 443)) {
+if (@($conf['force_https'] == 1) or (isset ($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] == 443)) {
     $https  = "https://{$_SERVER['SERVER_NAME']}";
 }
 else {
-    if ($_SERVER['SERVER_PORT'] != 80) {
-      $https  = "http://{$_SERVER['SERVER_NAME']}:{$_SERVER['SERVER_PORT']}";
-    } else {
-      $https  = "http://{$_SERVER['SERVER_NAME']}";
+    if ( isset ($_SERVER['SERVER_PORT'] ) )
+    {
+        if ( $_SERVER['SERVER_PORT'] != 80) {
+          $https  = "http://{$_SERVER['SERVER_NAME']}:{$_SERVER['SERVER_PORT']}";
+        } else {
+          $https  = "http://{$_SERVER['SERVER_NAME']}";
+        }
     }
 }
 

--- a/www/include/functions_db.inc.php
+++ b/www/include/functions_db.inc.php
@@ -1142,7 +1142,7 @@ function ona_get_domain_record($array='', $order='') {
 function ona_get_dns_record($array='', $order='') {
     list($status, $rows, $record) = ona_get_record($array, 'dns', $order);
 
-    if ($record['type'] == 'A' or $record['type'] == 'TXT') {
+    if ($record['type'] == 'A' or $record['type'] == 'AAAA' or $record['type'] == 'TXT') {
         $record['fqdn'] = $record['name'].'.'.ona_build_domain_name($record['domain_id']);
         $record['domain_fqdn'] = ona_build_domain_name($record['domain_id']);
     }
@@ -1672,6 +1672,9 @@ function ona_find_domain($fqdn="", $returndefault=0) {
 //     }
 
     // FIXME: MP  rows is not right here..  need to look at fixing it.. rowsa/rowsb above doesnt translate.. do I even need that?
+    if ( !isset($rows) or !is_int($rows) ) {
+        $rows = 0;
+    }
     return(array($status, $rows, $domain));
 }
 

--- a/www/include/functions_general.inc.php
+++ b/www/include/functions_general.inc.php
@@ -145,7 +145,18 @@ function ona_logmsg($message, $logfile="") {
     }
 
     // Build the exact line we want to write to the file
-    $logdata = date("M j G:i:s ") . "{$uname['nodename']} {$username}@{$_SERVER['REMOTE_ADDR']}: [{$self['context_name']}] {$message}\n";
+    // Prevent Undefined index notice when running CLI.
+    if (isset ( $_SERVER['REMOTE_ADDR'] ) ) {
+	    $_remote_addr = $_SERVER['REMOTE_ADDR'];
+    } else {
+	    $_remote_addr = '';
+    }
+    if ( isset($self['context_name']) ) {
+        $_cn = $self['context_name'];
+    } else {
+        $_cn = '';
+    }
+    $logdata = date("M j G:i:s ") . "{$uname['nodename']} {$username}@{$_remote_addr}: [{$_cn}] {$message}\n";
 
     // Write the line to the file
     if (!fwrite($file, $logdata)) {
@@ -1222,7 +1233,7 @@ function startSession() {
     global $conf;
 
     // If the command line agent, dcm.pl, is making the request, don't really start a session.
-    if (preg_match('/console-module-interface/', $_SERVER['HTTP_USER_AGENT'])) {
+    if ( isset ($_SERVER['HTTP_USER_AGENT']) && preg_match('/console-module-interface/', $_SERVER['HTTP_USER_AGENT'])) {
 
         // Pretend to log them in
         if (preg_match('/unix_username=([^&]+?)(&|$)/', $_REQUEST['options'], $matches)) {

--- a/www/include/functions_gui.inc.php
+++ b/www/include/functions_gui.inc.php
@@ -141,7 +141,7 @@ function workspace_plugin_loader($modulename, $record=array(), $extravars=array(
     global $conf, $self, $base, $images, $color, $style, $onadb;
     $modhtml = '';
     $modjs = '';
-    $modwsmenu = '';
+    $modwsmenu = array();
     $modbodyhtml = '';
     $ws_plugin_dir = "{$base}/workspace_plugins";
 

--- a/www/include/functions_inet_format.php
+++ b/www/include/functions_inet_format.php
@@ -1,0 +1,17 @@
+<?php
+
+// ip_decimal is the ona/mysql decimal(39,0) value.
+//  $format is the format the ip address will be returned in:
+//  //    1 or numeric:  170666057
+//  //    2 or dotted:   10.44.40.73
+//
+function inet_format($ip_decimal)
+{
+
+	// function ip_mangle($ip="", $format="default")
+	$ip = ip_mangle ( $ip_decimal, 2); // dotted 
+	return inet_pton($ip);
+
+}
+
+?>

--- a/www/modules/ona/domain.inc.php
+++ b/www/modules/ona/domain.inc.php
@@ -209,6 +209,34 @@ EOM
         $self['error'] = "ERROR => domain_add() SQL Query failed: " . $self['error'];
         printmsg($self['error'],0);
         return(array(7, $self['error'] . "\n"));
+    } else {
+	// FIXME: HACK for Bind-DLZ - need an SOA record in
+	// interface ID doesn't matter
+    $dns_id = ona_get_next_id('dns');
+
+    // Add the dns record
+    list($status, $rows) = db_insert_record(
+        $onadb,
+        'dns',
+        array(
+            'id'                   => $dns_id,
+            'domain_id'            => $id,
+            'interface_id'         => 0,
+            'dns_id'               => 0,
+            'type'                 => 'SOA',
+            'ttl'                  => 0,
+            'name'                 => '',
+            'mx_preference'        => '0',
+            'txt'                  => '',
+            'srv_pri'              => 0,
+            'srv_weight'           => 0,
+            'srv_port'             => 0,
+            'notes'                => '',
+            'dns_view_id'          => 0
+       )
+	);
+
+
     }
 
 

--- a/www/modules/ona/interface.inc.php
+++ b/www/modules/ona/interface.inc.php
@@ -196,6 +196,7 @@ EOM
                 'host_id'                  => $host['id'],
                 'subnet_id'                => $subnet['id'],
                 'ip_addr'                  => $options['ip'],
+		'ip_addr_inet'		   => inet_format($options['ip']),
                 'mac_addr'                 => $options['mac'],
                 'name'                     => trim($options['name']),
                 'description'              => trim($options['description'])
@@ -477,8 +478,10 @@ EOM
         // Everything looks ok, add it to $SET
         if($interface['subnet_id'] != $subnet['id'])
             $SET['subnet_id'] = $subnet['id'];
-        if($interface['ip_addr'] != $options['set_ip'])
-            $SET['ip_addr'] = $options['set_ip'];
+	if($interface['ip_addr'] != $options['set_ip']) {
+		$SET['ip_addr'] = $options['set_ip'];
+		$SET['ip_addr_inet'] = inet_format($options['set_ip']);
+	}
     }
 
 

--- a/www/winc/list_records.inc.php
+++ b/www/winc/list_records.inc.php
@@ -365,6 +365,8 @@ EOL;
             }
             $record['name'] = preg_replace("/${domain_part}$/", '', $record['name']);
 
+	    printmsg("DEBUG => list_records : " . json_encode ( array ( 'record' => $record, 'pointsto' => $pointsto, 'pdomain' => $pdomain, 'parent' => $parent  ) ),  1);
+
             $data = <<<EOL
                     <a title="Edit DNS A record"
                        class="act"


### PR DESCRIPTION
See `docs/DPD-DLZ-INET-Chanages.md` within this branch for more information, but in short, this will allow BIND-DLZ to use ONA's database directly, without any views, with all queries using indexes ... and supporting full v6, both v4/v6 reverse lookups (PTRs), and return NS, SOA, and MX records correctly.

An auto upgrade path is not provided, I assume that would need to be formalize more at the time of merged and just before tagging for a release.  However,  `install/inet-functions.sql` needs to be applied to the database, before running `install/inet-functions.php`.

Backwards compatibility should have been retrained, so the changes *shouldn't* affect any other modules, plugins or code path, but extensive QA has not been done.  I don't expect this patch set to be merged as-is, but wanted to share with community as soon as I had it available.   

Please let me know any changes that would be required for getting this upstreamed. 

I've created this additional and patches as part of my employment as Director of Information Technology at iX Systems, Inc.  I'll be using my fork-and-branch (pending upstreaming merging) to deployed a new US nation-wide internal DNS system for company.