### PR TITLE
Fix ONA so that a third level dns domain can add a DNS server.

### DIFF
--- a/www/config/config.inc.php
+++ b/www/config/config.inc.php
@@ -217,7 +217,7 @@ foreach ($records as $record) {
 }
 
 // Include functions that replace the default session handler with one that uses MySQL as a backend
-require_once($conf['inc_db_sessions']);
+// require_once($conf['inc_db_sessions']);
 
 // Include the GUI functions
 require_once($conf['inc_functions_gui']);

--- a/www/include/functions_gui.inc.php
+++ b/www/include/functions_gui.inc.php
@@ -141,7 +141,7 @@ function workspace_plugin_loader($modulename, $record=array(), $extravars=array(
     global $conf, $self, $base, $images, $color, $style, $onadb;
     $modhtml = '';
     $modjs = '';
-    $modwsmenu = '';
+    $modwsmenu = array();
     $modbodyhtml = '';
     $ws_plugin_dir = "{$base}/workspace_plugins";
 
@@ -350,7 +350,7 @@ function get_host_suggestions($q, $max_results=10) {
                 list($status, $rows, $view) = db_get_record($onadb, 'dns_views', array('id' => $record['dns_view_id']));
                 $viewname = $view['name'].'/';
             }
-            $results[] = $viewname.$record[$field].".".$domain['name'];
+            $results[] = $viewname.$record[$field].".".ona_build_domain_name ( $record['domain_id'] );
         }
     }
 

--- a/www/modules/ona/dns_record.inc.php
+++ b/www/modules/ona/dns_record.inc.php
@@ -951,7 +951,7 @@ EOM
     $options['set_name'] = preg_replace("/^\./", '', $options['set_name']);
 
     // Find the DNS record from $options['name']
-    list($status, $rows, $dns) = ona_find_dns_record($options['name']);
+    list($status, $rows, $dns) = ona_find_dns_record($options['server'] . "." . $domain['fqdn']);
     printmsg("DEBUG => dns_record_modify() DNS record: {$dns['fqdn']}", 3);
     if ($rows > 1) {
         printmsg("DEBUG => Found more than one DNS record for: {$options['name']}",3);

--- a/www/modules/ona/domain_server.inc.php
+++ b/www/modules/ona/domain_server.inc.php
@@ -80,7 +80,7 @@ EOM
     printmsg("DEBUG => domain_server_add(): Found domain, {$domain['name']}", 3);
 
     // Determine the server is valid
-    list($status, $rows, $ns_dns) = ona_find_dns_record($options['server']);
+    list($status, $rows, $ns_dns) = ona_find_dns_record($options['server'] . "." . $domain['fqdn']);
     list($status, $rows, $interface) = ona_find_interface($ns_dns['interface_id']);
 
     $host['id'] = $interface['host_id'];
@@ -169,7 +169,7 @@ EOM
     if (!$dnsrows) {
         printmsg("DEBUG => Auto adding a NS record for {$options['server']}.", 0);
         // Run dns_record_add as a NS type
-        list($status, $output) = run_module('dns_record_add', array('name' => $domain['fqdn'],'pointsto' => $options['server'], 'type' => 'NS'));
+        list($status, $output) = run_module('dns_record_add', array('name' => $domain['fqdn'],'pointsto' => $options['server'] . "." . $domain['fqdn'], 'type' => 'NS'));
         if ($status)
             return(array($status, $output));
         $add_to_error .= $output;


### PR DESCRIPTION
When trying to organize domains into a third level domains, where for example,`tn.ixsystems.com` 's parent was `ixsystems.com` - I was unable to add a DNS servers.  Further more, the suggestion boxes, would only show `util1.ixsystems.com` and `util1.tn` - as seen in the screen shots below. No combination of server and domain would allow the DNS server to be added.

![screen shot 2018-04-24 at 4 43 09 pm](https://user-images.githubusercontent.com/5975474/39225125-76a80c62-47ff-11e8-8825-79bd4ef85be3.png)
![screen shot 2018-04-24 at 4 45 14 pm](https://user-images.githubusercontent.com/5975474/39225126-76c3619c-47ff-11e8-8f86-25c0111e4a92.png)

The attached changes, allow this host to be added, and correctly expands util1.tn host name to util1.tn.ixsystems.com.  However, the UI gets a little strange, as the server is then "util1.tn.ixsystems.com" and domain being "tn.ixsystems.com" ... it will functionally work as the FQDN in the server, or just the hostname "util1" and the domain "tn.ixsystems.com". 
