### PR TITLE
Apply group mappings to groupOfUniqueNames LDAP groups too

### DIFF
--- a/www/include/auth/ldap.class.php
+++ b/www/include/auth/ldap.class.php
@@ -250,9 +250,24 @@ class auth_ldap extends auth_local {
 
             if(is_array($result)) foreach($result as $grp){
                 if(!empty($grp[$this->cnf['groupkey']][0])){
+                    $groupname = $grp[$this->cnf['groupkey']][0];
                     if($this->cnf['debug'])
-                        printmsg('DEBUG => auth_ldap: LDAP usergroup: '.htmlspecialchars($grp[$this->cnf['groupkey']][0]),2);
-                    $info['grps'][$grp[$this->cnf['groupkey']][0]] = $g++;
+                        printmsg('DEBUG => auth_ldap: LDAP usergroup: '
+                        .htmlspecialchars($groupname),2);
+                    if(!empty($this->cnf['mapping']['grps'][$this->cnf['groupkey']])){
+                        $regexp = $this->cnf['mapping']['grps'][$this->cnf['groupkey']];
+                        printmsg('DEBUG => Matching '.htmlspecialchars($groupname)
+                                                     .' against '.htmlspecialchars($regexp),2);
+                        if (preg_match($regexp,$groupname,$match)) {
+                            $groupname_mapped = $match[1];
+                            if($this->cnf['debug'])
+                                printmsg('DEBUG => auth_ldap: mapped LDAP usergroup: '
+                                .htmlspecialchars($groupname_mapped),2);
+                            $info['grps'][$groupname_mapped] = $g++;
+                        }
+                    } else {
+                        $info['grps'][$groupname] = $g++;
+                    }
                 }
             }
         }

--- a/www/include/functions_auth.inc.php
+++ b/www/include/functions_auth.inc.php
@@ -68,7 +68,7 @@ function get_authentication($login_name='', $login_password='') {
     $js = "el('loginmsg').innerHTML = '<span style=\"color: green;\">Success!</span>'; setTimeout('removeElement(\'tt_loginform\')',1000);";
 
     // Validate the userid was passed and is "clean"
-    if (!preg_match('/^[A-Za-z0-9.\-_]+$/', $login_name)) {
+    if (!preg_match('/^[A-Za-z0-9.\-_@]+$/', $login_name)) {
         $js = "el('loginmsg').innerHTML = 'Bad username format';";
         printmsg("ERROR => Login failure for {$login_name}: Bad username format", 0);
         return(array(1, $js));


### PR DESCRIPTION
This patch adds mapping support for groupOfUniqueNames groups in LDAP authentication.

Example: 
1) The authenticated user is a member of the group `cn=PREFIX_ADMIN,cn=Groups,dc=example,dc=com`.
1) The following mapping is defined:   
  `$conf['auth']['ldap']['mapping']['grps'] = array('cn'=>'/PREFIX_(.+)/i');`
1) The user will be member of the ONA group `ADMIN`

Additionally there is a small tweak to allow email addresses as login names.
