### PR TITLE
fixes for PHP 7.2

### DIFF
--- a/www/config/config.inc.php
+++ b/www/config/config.inc.php
@@ -225,11 +225,11 @@ require_once($conf['inc_functions_gui']);
 // Include the AUTH functions
 require_once($conf['inc_functions_auth']);
 
-// Start the session handler (this calls a function defined in functions_general)
-startSession();
-
 // Set session inactivity threshold
 ini_set("session.gc_maxlifetime", $conf['cookie_life']);
+
+// Start the session handler (this calls a function defined in functions_general)
+startSession();
 
 // if search_results_per_page is in the session, set the $conf variable to it.  this fixes the /rows command
 if (isset($_SESSION['search_results_per_page'])) $conf['search_results_per_page'] = $_SESSION['search_results_per_page'];

--- a/www/include/adodb_sessions.inc.php
+++ b/www/include/adodb_sessions.inc.php
@@ -68,19 +68,20 @@ function sess_read($key) {
     printmsg("sess_read($key) called", 6);
 
     list($status, $rows, $record) = db_get_record($SESS_DBH, 'sessions', "`sesskey` = '$key' AND `expiry` > " . time());
-    if ($status or $rows == 0) { return false; }
+    if ($status or $rows == 0) { return ''; }
 
     if (array_key_exists('sessvalue', $record)) {
         // Update the expiry time (i.e. keep sessions alive even if nothing in the session has changed)
         $expiry = time() + $SESS_LIFE;
         list($status, $rows) = db_update_record($SESS_DBH, 'sessions', "`sesskey` = '$key' AND `expiry` > " . time(), array('expiry' => $expiry));
-        if ($status) { return false; }
+        if ($status) { return ''; }
 
-        // Return the value
+        // Return the value (but not a null)
+        if ( $record['sessvalue'] == NULL ) { return ''; }
         return($record['sessvalue']);
     }
 
-    return false;
+    return '';
 }
 
 

--- a/www/include/functions_gui.inc.php
+++ b/www/include/functions_gui.inc.php
@@ -141,7 +141,7 @@ function workspace_plugin_loader($modulename, $record=array(), $extravars=array(
     global $conf, $self, $base, $images, $color, $style, $onadb;
     $modhtml = '';
     $modjs = '';
-    $modwsmenu = '';
+    $modwsmenu = array();
     $modbodyhtml = '';
     $ws_plugin_dir = "{$base}/workspace_plugins";
 


### PR DESCRIPTION
This PR includes three PHP7.2 fixes:

PHP7.2 and $_SESSION not getting saved as discussed in [#130](https://github.com/opennetadmin/ona/issues/130).

The fix posted for [#129](https://github.com/opennetadmin/ona/issues/129)

A previously unknown but long time issue exposed by PHP7.2 now issuing a warning stating session was already started when trying to set gc.max_lifetime.