### PR TITLE
bugfix(auth_ldap,auth_local) migrate to new style `__construct`

### DIFF
--- a/www/include/auth/ldap.class.php
+++ b/www/include/auth/ldap.class.php
@@ -14,9 +14,11 @@ class auth_ldap extends auth_local {
     var $founduser = false;
 
     /**
-     * Constructor
+     * Constructor: auth_ldap
+     *
+     * Reads configuration and checks for PHP LDAP module.
      */
-    function auth_ldap(){
+    function __construct(){
         global $conf,$base;
 
         // load in system default ldap config

--- a/www/include/auth/local.class.php
+++ b/www/include/auth/local.class.php
@@ -15,15 +15,15 @@ class auth_local {
   var $user = null;
 
   /**
-   * Constructor.
+   * Constructor: auth_local
    *
    * Carry out sanity checks to ensure the object is
    * able to operate.
    *
    * @author  Christopher Smith <chris@jalakai.co.uk>
    */
-  function auth_local() {
-     // the base class constructor does nothing, derived class
+  function __construct() {
+    // the base class constructor does nothing, derived class
     // constructors do the real work
   }
 


### PR DESCRIPTION
There are wired errors which can be tackeled down that the class attributes are not set, because the constructor is not called.

php8 do not support the old-syntax for constructors any more, so  using  `__construct` is required.