### PR TITLE
Fix tooltips undefined constant error

### DIFF
--- a/www/winc/tooltips.inc.php
+++ b/www/winc/tooltips.inc.php
@@ -1564,7 +1564,7 @@ function get_interface_cluster_list_html($form) {
     list($status, $rows, $priint) = ona_get_interface_record(array('id'=>$form['interface_id']));
     list($status, $rows, $prihost) = ona_get_host_record(array('id'=>$priint['host_id']));
 
-    $priip = ip_mangle($priint['ip_addr'], dotted);
+    $priip = ip_mangle($priint['ip_addr'], 'dotted');
 
     // add one for primary host
     $introws=$introws+1;


### PR DESCRIPTION
When hovering over a shared IP, the tooltips box doesn't display correctly in php8.1 (Ubuntu 22.04) or php8.3 (Ubuntu 24.04) and throws the included error.

PHP Fatal error:  Uncaught Error: Undefined constant "dotted" in /opt/ona/www/winc/tooltips.inc.php:1567\nStack trace:\n#0 /opt/ona/www/winc/tooltips.inc.php(98): get_interface_cluster_list_html()\n#1 /opt/ona/www/include/xajax_webwin/webwin.inc.php(173): ws_tooltips_submit()\n#2 /opt/ona/www/include/xajax/xajax_core/plugin_layer/support/xajaxUserFunction.inc.php(237): window_submit()\n#3 /opt/ona/www/include/xajax/xajax_core/plugin_layer/xajaxFunctionPlugin.inc.php(228): xajaxUserFunction->call()\n#4 /opt/ona/www/include/xajax/xajax_core/xajaxPluginManager.inc.php(277): xajaxFunctionPlugin->processRequest()\n#5 /opt/ona/www/include/xajax/xajax_core/xajax.inc.php(603): xajaxPluginManager->processRequest()\n#6 /opt/ona/www/include/xajax_setup.inc.php(49): xajax->processRequest()\n#7 /opt/ona/www/index.php(50): require_once('...')\n#8 {main}\n  thrown in /opt/ona/www/winc/tooltips.inc.php on line 1567